### PR TITLE
Fix help message for CLI

### DIFF
--- a/linux/TicketSolverCLI.cpp
+++ b/linux/TicketSolverCLI.cpp
@@ -7,12 +7,12 @@
 int main (int argc, char **argv)
 {
 	if ((argc < 2) || (argc > 3)) {
-		printf ("TicketSolverGUI [-v] [digits] [target result]\r\n");
+		printf ("ticketsolver [-v] [digits] [target result]\r\n");
 		printf ("  -v            - show version\r\n");
 		printf ("  digits        - digits of ticket number\r\n");
 		printf ("  target result - target result of expression, default 100\r\n");
 		printf ("Example\r\n");
-		printf ("  TicketSolverGUI 123456\r\n");
+		printf ("  ticketsolver 123456\r\n");
 		return 0;
 	}
 


### PR DESCRIPTION
`Makefile` is configured in a way that the output executable is called `ticketsolver`, but the built-in doc for the executable states the executable name should be `TicketSolverGUI`:

```
$ ./ticketsolver
TicketSolverGUI [-v] [digits] [target result]
  -v            - show version
  digits        - digits of ticket number
  target result - target result of expression, default 100
Example
  TicketSolverGUI 123456
```

This pull request updates the output so that it matches the real output filename.

BTW, the solver itself compiles perfectly on a Mac with LLVM:

```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 7.0.0 (clang-700.1.76)
Target: x86_64-apple-darwin15.0.0
Thread model: posix
```
